### PR TITLE
make wrapActionCreators work for redux-thunk actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "eloytoro",
   "license": "MIT",
   "dependencies": {
+    "lodash.flowright": "^3.5.0",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.isnil": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "eloytoro",
   "license": "MIT",
   "dependencies": {
-    "lodash.flowright": "^3.5.0",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.isnil": "^4.0.0",
@@ -37,11 +36,12 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-3": "^6.17.0",
     "enzyme": "^2.6.0",
-    "jest": "^17.0.0",
+    "jest": "^23.0.0",
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-test-renderer": "^15.3.2",
+    "redux-thunk": "^2.3.0",
     "webpack": "1.13.0",
     "webpack-node-externals": "^1.5.4"
   },

--- a/src/commons.js
+++ b/src/commons.js
@@ -5,6 +5,7 @@ import { NAME_KEY, UUID_KEY } from './constants';
 import isPlainObject from 'lodash.isplainobject';
 import isNil from 'lodash.isnil';
 import get from 'lodash.get';
+import compose from 'lodash.flowright';
 
 
 export const createUUID = () => v4();
@@ -38,9 +39,12 @@ export const wrapActionCreators = (actionCreator, name, uuid) => {
           return augmentAction(action, name, uuid);
       } else {
           // for redux-thunk
-          const augmentDispatch = dispatch => action => dispatch(wrapAction(action));
           return (dispatch) => action(augmentDispatch(dispatch));
       }
+  }
+
+  function augmentDispatch(dispatch) {
+      return compose(dispatch,wrapAction);
   }
 
   return (...args) => wrapAction(actionCreator(...args));

--- a/src/commons.js
+++ b/src/commons.js
@@ -35,17 +35,26 @@ export const wrapActionCreators = (actionCreator, name, uuid) => {
 
   return (...args) => {
     const action = actionCreator(...args);
-    return {
-      ...action,
-      meta: Object.assign(
-        {},
-        action.meta,
-        name && { [NAME_KEY]: name },
-        uuid && { [UUID_KEY]: uuid },
-      )
-    };
+    if (isPlainObject(action)) {
+        return augmentAction(action, name, uuid);
+    } else {
+      // for redux-thunk
+      const augmentDispatch = dispatch => action => dispatch(augmentAction(action, name, uuid));
+      return (dispatch) => action(augmentDispatch(dispatch));
+    }
   };
 };
+
+const augmentAction = (action, name, uuid) => {
+  return {
+    ...action,
+    meta: Object.assign(
+        {},
+        action.meta,
+        name && {[NAME_KEY]: name},
+        uuid && {[UUID_KEY]: uuid},
+    )
+  }};
 
 export const wrapMapStateToProps = (mapStateToProps, name) => (state, props) => {
   if (isNil(mapStateToProps)) return {};

--- a/src/commons.js
+++ b/src/commons.js
@@ -1,12 +1,10 @@
 import { v4 } from 'uuid';
 import mapValues from 'lodash.mapvalues';
-import { bindActionCreators } from 'redux';
+import { bindActionCreators, compose } from 'redux';
 import { NAME_KEY, UUID_KEY } from './constants';
 import isPlainObject from 'lodash.isplainobject';
 import isNil from 'lodash.isnil';
 import get from 'lodash.get';
-import compose from 'lodash.flowright';
-
 
 export const createUUID = () => v4();
 export const getUUIDState = (state, name, ...args) => get(state, ['uuid', name, ...args]);

--- a/src/commons.js
+++ b/src/commons.js
@@ -33,16 +33,17 @@ export const wrapActionCreators = (actionCreator, name, uuid) => {
     return mapValues(actionCreator, ac => wrapActionCreators(ac, name, uuid));
   }
 
-  return (...args) => {
-    const action = actionCreator(...args);
-    if (isPlainObject(action)) {
-        return augmentAction(action, name, uuid);
-    } else {
-      // for redux-thunk
-      const augmentDispatch = dispatch => action => dispatch(augmentAction(action, name, uuid));
-      return (dispatch) => action(augmentDispatch(dispatch));
-    }
-  };
+  function wrapAction(action) {
+      if (isPlainObject(action)) {
+          return augmentAction(action, name, uuid);
+      } else {
+          // for redux-thunk
+          const augmentDispatch = dispatch => action => dispatch(wrapAction(action));
+          return (dispatch) => action(augmentDispatch(dispatch));
+      }
+  }
+
+  return (...args) => wrapAction(actionCreator(...args));
 };
 
 const augmentAction = (action, name, uuid) => {

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -68,7 +68,6 @@ describe.each([false,true])('connect thunk:%o', (useThunk) => {
 
     it('updates the component', () => {
       incr()
-      //store.dispatch({ type: '@', meta: { [UUID_KEY]: uuid, [NAME_KEY]: 'counter' } })
       expect(component.props().count).toBe(2)
     })
 
@@ -100,7 +99,8 @@ describe.each([false,true])('connect thunk:%o', (useThunk) => {
   describe('explicitly', () => {
     const uuid = 'NON_UUID_KEY'
     const store = setupStore(useThunk)
-    const incr = setupAction(store,uuid,useThunk);
+    const incr = setupAction(store,uuid,useThunk)
+
     store.dispatch(registerUUID('counter', uuid))
     const root = setupRoot(store, { uuid })
     const component = root.find(Component)

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -5,7 +5,6 @@ import { UUID_KEY, NAME_KEY } from '../src/constants'
 import { registerUUID } from '../src/actions'
 import createReducer from '../src/createReducer'
 import connectUUID from '../src/connect'
-import { wrapMapDispatchToProps} from '../src/commons'
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 
@@ -22,7 +21,7 @@ const Component = () => (
   <div />
 )
 
-const ConnectedComponent = connectUUID('counter', state => ({ count: state }))(Component)
+const createConnectedComponent = (useThunk) => connectUUID('counter', state => ({ count: state }), setupActionCreators(useThunk))(Component)
 
 const setupStore = (useThunk) => {
   const store = useThunk ? createStore(reducer, applyMiddleware(thunkMiddleware)) : createStore(reducer)
@@ -32,25 +31,27 @@ const setupStore = (useThunk) => {
   return store
 }
 
-const setupAction = (store, uuid, useThunk) => {
+const setupActionCreators = (useThunk) => {
   const actionCreators = {}
   if (useThunk) {
       actionCreators.incr = () => (dispatch) => dispatch({type: '@'})
   } else {
       actionCreators.incr = () => {return {type: '@'}}
   }
-  const {incr} = wrapMapDispatchToProps(actionCreators,'counter')(store.dispatch,{uuid})()
-  return incr
+  return actionCreators
 }
 
-const setupRoot = (store, props) => mount(
-  <Provider store={store}>
-    <ConnectedComponent {...props} />
-  </Provider>
-)
+const setupRoot = (store, props, useThunk) => {
+  const ConnectedComponent = createConnectedComponent(useThunk)
+  return mount(
+        <Provider store={store}>
+            <ConnectedComponent {...props} />
+        </Provider>
+    )
+}
 
 describe.each([false,true])('connect thunk:%o', (useThunk) => {
-  const assertBehavior = (store, component, uuid, incr) => {
+  const assertBehavior = (store, component, uuid) => {
     it('connects the component to the uuid state', () => {
       const props = component.props()
       expect(props.count).toBe(1)
@@ -67,7 +68,7 @@ describe.each([false,true])('connect thunk:%o', (useThunk) => {
     })
 
     it('updates the component', () => {
-      incr()
+      component.props().incr()
       expect(component.props().count).toBe(2)
     })
 
@@ -79,14 +80,13 @@ describe.each([false,true])('connect thunk:%o', (useThunk) => {
 
   describe('implicitly', () => {
     const store = setupStore(useThunk)
-    const root = setupRoot(store)
+    const root = setupRoot(store, {}, useThunk)
 
     const component = root.find(Component)
 
     const uuid = component.props().uuid
-    const incr = setupAction(store,uuid,useThunk);
 
-    assertBehavior(store, component, uuid, incr)
+    assertBehavior(store, component, uuid)
 
     it('unmounts the component', () => {
       const calls = store.dispatch.mock.calls.length
@@ -99,13 +99,12 @@ describe.each([false,true])('connect thunk:%o', (useThunk) => {
   describe('explicitly', () => {
     const uuid = 'NON_UUID_KEY'
     const store = setupStore(useThunk)
-    const incr = setupAction(store,uuid,useThunk)
 
     store.dispatch(registerUUID('counter', uuid))
-    const root = setupRoot(store, { uuid })
+    const root = setupRoot(store, { uuid }, useThunk)
     const component = root.find(Component)
 
-    assertBehavior(store, component, uuid, incr)
+    assertBehavior(store, component, uuid)
 
     it('unmounts the component', () => {
       const calls = store.dispatch.mock.calls.length


### PR DESCRIPTION
With the redux-thunk middleware, the return value from an action creator isn't a plain action, but a function that expects the dispatch as an argument, and applies this dispatch function to plain actions.

This PR makes wrapActionCreators work for these kind of actions.
All the connect tests are performed with and without redux-thunk.